### PR TITLE
Change the pd threshold from 0.6->0.1

### DIFF
--- a/q_lib/include/q/pitch/period_detector.hpp
+++ b/q_lib/include/q/pitch/period_detector.hpp
@@ -21,7 +21,7 @@ namespace cycfi::q
    {
    public:
 
-      static constexpr float pulse_threshold = 0.6;
+      static constexpr float pulse_threshold = 0.1;
       static constexpr float harmonic_periodicity_factor = 16;
       static constexpr float periodicity_diff_factor = 0.8 / 100; // % of the midpoint
 


### PR DESCRIPTION
Looking at an application which needs a pure version of the periodicity for further analysis. Default setting of 0.6 filters out too much of the signal.